### PR TITLE
fixed IEnumerable.Find for structs

### DIFF
--- a/LaYumba.Functional.Tests/EnumerableExtTests.cs
+++ b/LaYumba.Functional.Tests/EnumerableExtTests.cs
@@ -1,0 +1,27 @@
+﻿using System.Linq;
+using FsCheck;
+using FsCheck.Xunit;
+using Xunit;
+using static LaYumba.Functional.F;
+
+namespace LaYumba.Functional.Tests
+{
+    public class EnumerableExtTests
+    {
+        [Property]
+        public void Find_AnyInNonEmptyStrings_First(NonEmptyArray<NonNull<string>> list)
+            => Assert.Equal(Some(list.Get[0].Get), list.Get.Map(x => x.Get).Find(_ => true));
+
+        [Property]
+        public void Find_AnyInNonEmptyDecimals_First(NonEmptyArray<decimal> list)
+            => Assert.Equal(Some(list.Get[0]), list.Get.Find(_ => true));
+
+        [Fact]
+        public void Find_EmptyStrings_None()
+            => Assert.Equal(None, Enumerable.Empty<string>().Find(_ => true));
+
+        [Fact]
+        public void Find_EmptyDecimals_None()
+            => Assert.Equal(None, Enumerable.Empty<decimal>().Find(_ => true));
+    }
+}

--- a/LaYumba.Functional/EnumerableExt.cs
+++ b/LaYumba.Functional/EnumerableExt.cs
@@ -22,7 +22,7 @@ namespace LaYumba.Functional
       }
 
       public static Option<T> Find<T>(this IEnumerable<T> source, Func<T, bool> predicate)
-         => source.FirstOrDefault(predicate);
+         => source.Where(predicate).Head();
 
       public static T FirstOr<T>(this IEnumerable<T> source, T defaultValue)
          => source.Head().Match(


### PR DESCRIPTION
Hi!

This is a fix for `IEnumerable<T>.Find`. With `FirstOrDefault` it always returns `Some` for structs. See `Find_EmptyDecimals_None` test.